### PR TITLE
Add specific error message for droplet not found

### DIFF
--- a/cf/cmd/push.go
+++ b/cf/cmd/push.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"flag"
 	"fmt"
+	"os"
 )
 
 type Push struct {
@@ -48,8 +49,12 @@ func (p *Push) Run(args []string) error {
 }
 
 func (p *Push) pushDroplet(name string) error {
-	droplet, size, err := p.FS.ReadFile(fmt.Sprintf("./%s.droplet", name))
+	filename := fmt.Sprintf("./%s.droplet", name)
+	droplet, size, err := p.FS.ReadFile(filename)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("file does not exist: %s: Did you provide a filepath instead of an app name?", filename)
+		}
 		return err
 	}
 	defer droplet.Close()

--- a/cf/cmd/push_test.go
+++ b/cf/cmd/push_test.go
@@ -3,6 +3,7 @@ package cmd_test
 import (
 	"io"
 	"io/ioutil"
+	"os"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -80,6 +81,14 @@ var _ = Describe("Push", func() {
 			Expect(cmd.Run([]string{"push", "some-app", "-e"})).To(Succeed())
 			Expect(droplet.Result()).To(BeEmpty())
 			Expect(mockUI.Out).To(gbytes.Say("Successfully pushed: some-app"))
+		})
+
+		Context("app name is set as droplet file path", func() {
+			It("has a specific error message", func() {
+				mockFS.EXPECT().ReadFile("././some-app.droplet.droplet").Return(nil, int64(0), os.ErrNotExist)
+				err := cmd.Run([]string{"push", "./some-app.droplet"})
+				Expect(err).To(MatchError("file does not exist: ././some-app.droplet.droplet: Did you provide a filepath instead of an app name?"))
+			})
 		})
 
 		// TODO: test without setting env or restarting


### PR DESCRIPTION
Several users have reported trying to use the droplet path when pushing, eg. "cf local push ./my-app.droplet".
cflocal will now report a more helpful error message in thses circumstances.